### PR TITLE
Implemented true command

### DIFF
--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -8,3 +8,4 @@ from cat import cat
 from clear import clear
 from grep import grep
 from mkdir import mkdir
+from true import true

--- a/commands/true.py
+++ b/commands/true.py
@@ -1,0 +1,6 @@
+class true():
+    def __init__(self):
+        pass
+
+    def execute(self, cls):
+        pass

--- a/terminal.py
+++ b/terminal.py
@@ -33,6 +33,8 @@ class Terminal:
         show_path = show_path[-2:]
         show_path = "/".join(show_path)
         command = raw_input('{}$ '.format(show_path))
+        if command == '':
+            return 'true'
         return command
 
     def play(self):


### PR DESCRIPTION
Implemented the linux command `true` which does **nothing** . Fixed a bug using `true` command which causes a crash if an empty line is given as input at startup. 

Returning `true` whenever an empty line is given as input solves two problems:
- It stops the crash at startup from empty input due to `executor` being undefined.
- The shell does not execute previous command automatically due to empty input.
  - This fixes crashes of the likes which happen if you enter empty line after `cd ..` etc.